### PR TITLE
Spring cleaning

### DIFF
--- a/Source/RhythmCodex.Lib.Test/Ddr/Integration/Ddr573AudioIntegrationTests.cs
+++ b/Source/RhythmCodex.Lib.Test/Ddr/Integration/Ddr573AudioIntegrationTests.cs
@@ -23,7 +23,7 @@ public class Ddr573AudioIntegrationTests : BaseIntegrationFixture
         var decrypter = Resolve<IDigital573AudioDecrypter>();
         var keyProvider = Resolve<IDigital573AudioKeyProvider>();
         var key = keyProvider.Get(data);
-        var observed = decrypter.DecryptNew(data, key);
+        var observed = decrypter.DecryptNew(data, key!);
         observed.Data.ShouldBeEquivalentTo(expected);
     }
 
@@ -42,7 +42,7 @@ public class Ddr573AudioIntegrationTests : BaseIntegrationFixture
         var decrypter = Resolve<IDigital573AudioDecrypter>();
         var keyProvider = Resolve<IDigital573AudioKeyProvider>();
         var key = keyProvider.Get(data);
-        var observed = decrypter.DecryptOld(data, key[0]);
+        var observed = decrypter.DecryptOld(data, key![0]);
         observed.Data.ShouldBeEquivalentTo(expected);
     }
 }

--- a/Source/RhythmCodex.Lib.Test/Twinkle/Integration/TwinkleBeatmaniaIntegrationTests.cs
+++ b/Source/RhythmCodex.Lib.Test/Twinkle/Integration/TwinkleBeatmaniaIntegrationTests.cs
@@ -99,7 +99,7 @@ public class TwinkleBeatmaniaIntegrationTests : BaseIntegrationFixture
         var dsp = Resolve<IAudioDsp>();
         var options = new ChartRendererOptions();
 
-        using var stream = File.OpenRead(@"Z:\Bemani\Beatmania Non-PC\iidx7th.zip");
+        using var stream = File.OpenRead(@"/Users/saxxon/iidx7th.zip");
         using var zipStream = new ZipArchive(stream, ZipArchiveMode.Read);
         var entry = zipStream.Entries.Single();
         using var entryStream = entry.Open();
@@ -114,7 +114,7 @@ public class TwinkleBeatmaniaIntegrationTests : BaseIntegrationFixture
             foreach (var chart in archive.Charts.AsParallel())
             {
                 var rendered = dsp.Normalize(renderer.Render(chart.Events, archive.Samples, options), 1.0f, false);
-                this.WriteSound(rendered, Path.Combine($"twinkle7\\{chunk.Index:D4}_{(int) chart[NumericData.Id]:D2}.wav"));
+                this.WriteSound(rendered, Path.Combine("twinkle7", $"{chunk.Index:D4}_{(int) chart[NumericData.Id]!:D2}.wav"));
             }
         }
     }

--- a/Source/RhythmCodex.Lib/RhythmCodex.csproj
+++ b/Source/RhythmCodex.Lib/RhythmCodex.csproj
@@ -6,7 +6,6 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2024.3.0" />
-        <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
         <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="9.0.5" />
         <PackageReference Include="System.Text.Encoding.CodePages" Version="9.0.5" />
     </ItemGroup>

--- a/Source/RhythmCodex.Lib/Sounds/Models/Sound.cs
+++ b/Source/RhythmCodex.Lib/Sounds/Models/Sound.cs
@@ -7,5 +7,5 @@ namespace RhythmCodex.Sounds.Models;
 [Model]
 public class Sound : Metadata
 {
-    public List<Sample> Samples { get; set; }
+    public List<Sample> Samples { get; set; } = [];
 }

--- a/Source/RhythmCodex.Lib/Twinkle/Converters/ITwinkleBeatmaniaDecoder.cs
+++ b/Source/RhythmCodex.Lib/Twinkle/Converters/ITwinkleBeatmaniaDecoder.cs
@@ -5,6 +5,6 @@ namespace RhythmCodex.Twinkle.Converters;
 
 public interface ITwinkleBeatmaniaDecoder
 {
-    TwinkleArchive Decode(TwinkleBeatmaniaChunk chunk);
+    TwinkleArchive? Decode(TwinkleBeatmaniaChunk chunk);
     BeatmaniaPcSongSet MigrateToBemaniPc(TwinkleBeatmaniaChunk chunk);
 }

--- a/Source/RhythmCodex.Lib/Twinkle/Converters/TwinkleBeatmaniaDecoder.cs
+++ b/Source/RhythmCodex.Lib/Twinkle/Converters/TwinkleBeatmaniaDecoder.cs
@@ -32,7 +32,7 @@ public class TwinkleBeatmaniaDecoder(
         .Select(i => i * 0x4000 + 0x2000)
         .ToArray();
 
-    public TwinkleArchive Decode(TwinkleBeatmaniaChunk chunk)
+    public TwinkleArchive? Decode(TwinkleBeatmaniaChunk chunk)
     {
         if (chunk?.Data == null || chunk.Data.Length < 0x1A00000)
             return null;

--- a/Source/RhythmCodex.Lib/Twinkle/Model/TwinkleConstants.cs
+++ b/Source/RhythmCodex.Lib/Twinkle/Model/TwinkleConstants.cs
@@ -11,6 +11,9 @@ public static class TwinkleConstants
 
     private static readonly Lazy<BigRational[]> VolumeTableLazy = new(() =>
     {
+        // This algorithm is based on the one written into MAME:
+        // https://github.com/mamedev/mame/blob/master/src/devices/sound/rf5c400.cpp
+
         var result = new BigRational[256];
         var max = BigRational.One;
         for (var i = 0; i < 256; i++)

--- a/Source/RhythmCodex.Plugin.DependencyInjection/RhythmCodex.Plugin.DependencyInjection.csproj
+++ b/Source/RhythmCodex.Plugin.DependencyInjection/RhythmCodex.Plugin.DependencyInjection.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RhythmCodex.Lib\RhythmCodex.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Source/RhythmCodex.Plugin.DependencyInjection/RhythmCodexService.cs
+++ b/Source/RhythmCodex.Plugin.DependencyInjection/RhythmCodexService.cs
@@ -1,10 +1,9 @@
-using System;
 using Microsoft.Extensions.DependencyInjection;
 using RhythmCodex.Arc;
 using RhythmCodex.Beatmania;
 using RhythmCodex.IoC;
 
-namespace RhythmCodex;
+namespace RhythmCodex.Plugin.DependencyInjection;
 
 public class RhythmCodexService : IRhythmCodexService, IDisposable
 {

--- a/Source/RhythmCodex.sln
+++ b/Source/RhythmCodex.sln
@@ -35,18 +35,18 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RhythmCodex.Plugin.SevenZip", "RhythmCodex.Plugin.SevenZip\RhythmCodex.Plugin.SevenZip.csproj", "{7A815285-3FAC-4021-B00D-EFE23AE4988C}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Docs", "Docs", "{44A45635-5452-4399-99D9-40F6A496A2C1}"
-ProjectSection(SolutionItems) = preProject
-	..\.gitignore = ..\.gitignore
-	..\DESIGN.md = ..\DESIGN.md
-	..\LICENSE.md = ..\LICENSE.md
-	..\README.md = ..\README.md
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		..\.gitignore = ..\.gitignore
+		..\DESIGN.md = ..\DESIGN.md
+		..\LICENSE.md = ..\LICENSE.md
+		..\README.md = ..\README.md
+	EndProjectSection
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{C33870F0-797F-4C36-9CBB-14CAF0E1235E}"
-ProjectSection(SolutionItems) = preProject
-	..\publish.bat = ..\publish.bat
-	..\publish.sh = ..\publish.sh
-EndProjectSection
+	ProjectSection(SolutionItems) = preProject
+		..\publish.bat = ..\publish.bat
+		..\publish.sh = ..\publish.sh
+	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "XwbExtract", "XwbExtract\XwbExtract.csproj", "{3DC90D6E-B7DE-4D5B-AE32-43331C1819F3}"
 EndProject
@@ -57,6 +57,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RhythmCodex.Plugin.SharpZipLib", "RhythmCodex.Plugin.SharpZipLib\RhythmCodex.Plugin.SharpZipLib.csproj", "{489D1E8C-8653-4D37-80E7-885F5004411A}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RhythmCodex.Test", "RhythmCodex.Test\RhythmCodex.Test.csproj", "{6D428D79-7BB1-42E3-9783-D5BA284D32A5}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RhythmCodex.Plugin.DependencyInjection", "RhythmCodex.Plugin.DependencyInjection\RhythmCodex.Plugin.DependencyInjection.csproj", "{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -132,6 +134,10 @@ Global
 		{6D428D79-7BB1-42E3-9783-D5BA284D32A5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{6D428D79-7BB1-42E3-9783-D5BA284D32A5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{6D428D79-7BB1-42E3-9783-D5BA284D32A5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -154,5 +160,6 @@ Global
 		{D6BA6668-839A-4834-ABB2-35F06B08D4D9} = {DA4CAEFE-6816-430B-908B-C6D0F8796AEC}
 		{489D1E8C-8653-4D37-80E7-885F5004411A} = {DA4CAEFE-6816-430B-908B-C6D0F8796AEC}
 		{6D428D79-7BB1-42E3-9783-D5BA284D32A5} = {CA5B22D7-6992-4458-A162-3AC980DC032C}
+		{7E92C74E-B6A6-45C0-86FD-8EF3363B8B46} = {DA4CAEFE-6816-430B-908B-C6D0F8796AEC}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Moved a direct reference to Microsoft.DependencyInjection out of the library, only Abstractions are referenced now so that other libraries can take its place
- Fixed some bugs around Twinkle sound decoding
- Added SIMD optimization for the audio gain DSP (and will be looking at future opportunities to vectorize DSP)
- Replaced the old DDR 573 decryption method with a revised one from MAME (windyfairy)
- Fix parallelism in tests by giving each test its own DI container